### PR TITLE
feat(jit): JIT_EVENTS=full per-event stream + schema versioning

### DIFF
--- a/projects/monkey-lang/JIT_EVENTS_SCHEMA.md
+++ b/projects/monkey-lang/JIT_EVENTS_SCHEMA.md
@@ -1,0 +1,288 @@
+# JIT Event Schema
+
+The Monkey JIT can emit a per-event JSON Lines stream on stderr describing
+its internal lifecycle: which loops became hot, which traces were recorded,
+what IR each trace produced, when guards fired, when traces aborted and
+why, when traces were blacklisted, when side traces were promoted, etc.
+The stream is opt-in via the `JIT_EVENTS` environment variable and intended
+for fuzzing tools (mimule, lafleur-style differential fuzzers) and
+debugging.
+
+## Modes
+
+```
+JIT_EVENTS=off       (default) no events emitted, no overhead
+JIT_EVENTS=summary   end-of-run summary blob only (same as --trace-info)
+JIT_EVENTS=full      summary blob + per-event JSON Lines stream
+```
+
+The `--trace-info` CLI flag is equivalent to `JIT_EVENTS=summary`. Setting
+both is harmless; `JIT_EVENTS=full` is the strongest setting and supersedes
+the others.
+
+## Output format
+
+When the stream is enabled, each event is one line of stderr containing a
+single JSON object. Lines are independent — there is no surrounding array
+or framing. Consumers should split on `\n` and parse each non-empty line
+with `JSON.parse`.
+
+Every event carries:
+
+- `v`: schema version (currently always `1`)
+- `t`: event type (string, see vocabulary below)
+- `key`: trace identifier as `"<closureId>:<startIp>"` (most events)
+
+Other fields are event-specific. Consumers MUST ignore unknown event types
+and unknown fields so the schema can evolve additively without breaking
+older clients.
+
+## Event vocabulary
+
+### `loop_hot`
+
+A loop back-edge counter crossed `HOT_LOOP_THRESHOLD` (currently 16). A
+trace recording will start at this site on the next dispatch.
+
+```json
+{"v":1,"t":"loop_hot","key":"42:108","count":16}
+```
+
+### `func_hot`
+
+A function call counter crossed `HOT_FUNC_THRESHOLD` (currently 16). The
+JIT will attempt to compile the function as a method (not a trace).
+
+```json
+{"v":1,"t":"func_hot","fn_id":7,"count":16}
+```
+
+### `trace_start`
+
+Recorder began capturing a new trace. `kind` is one of:
+
+- `"loop"` — root trace at a hot loop header
+- `"side"` — side trace from a guard exit (also includes `parent` and `guard_idx`)
+- `"func"` — function trace (also includes `num_args`)
+
+```json
+{"v":1,"t":"trace_start","key":"42:108","kind":"loop"}
+{"v":1,"t":"trace_start","key":"42:200","kind":"side","parent":"42:108","guard_idx":3}
+{"v":1,"t":"trace_start","key":"99:0","kind":"func","num_args":2}
+```
+
+### `uop`
+
+One IR instruction emitted into the recording trace. This is the
+**highest-volume event** — a typical hot trace produces 20–100 of these.
+Payload is intentionally minimal (opcode + the most useful operand
+identifiers, no values) to keep stream size manageable. Mimule's coverage
+manager increments `uops[op]` on each one.
+
+```json
+{"v":1,"t":"uop","key":"42:108","op":"add_int"}
+{"v":1,"t":"uop","key":"42:108","op":"load_local","slot":0}
+{"v":1,"t":"uop","key":"42:108","op":"load_global","index":21}
+{"v":1,"t":"uop","key":"42:108","op":"guard_int","ref":3}
+```
+
+The full opcode vocabulary is the `IR` enum in `src/jit.js` (46 opcodes
+covering constants, loads/stores, arithmetic, comparison, guards,
+control flow, function calls, array/hash ops, builtins, and boxing).
+
+### `guard`
+
+A guard instruction was emitted. Fires **in addition to** the `uop` event
+for the same instruction — gives consumers a separate guard channel
+without having to filter `uop` events by opcode prefix. Includes
+`guard_idx` (the index in the trace's IR list) so it can be correlated
+with later `trace_exit` events that name the same `guard_idx`.
+
+```json
+{"v":1,"t":"guard","key":"42:108","op":"guard_int","guard_idx":3,"ref":2}
+```
+
+### `trace_complete`
+
+The recorder finished a trace successfully (reached the loop header again
+for a loop trace, or returned for a function trace). The trace will be
+optimized and compiled next.
+
+```json
+{"v":1,"t":"trace_complete","key":"42:108","ir":24,"guards":3}
+```
+
+`ir` and `guards` are the pre-optimization counts.
+
+### `trace_abort`
+
+The recorder bailed out mid-trace. `reason` is one of:
+
+| Reason | When |
+|-|-|
+| `instr_count_max` | Trace exceeded 200 IR instructions |
+| `instr_count_max_func` | Same, for function-trace path |
+| `float_arith` | Float operands during int arithmetic |
+| `float_negate` | Unary minus on a float |
+| `bool_compare` | Comparison between booleans |
+| `mixed_numeric_compare` | Comparison mixing int and float |
+| `string_compare` | String comparison |
+| `null_compare` | Comparison involving null |
+| `enum_compare` | Comparison between enums |
+| `array_lit` | Array literal construction |
+| `hash_lit` | Hash literal construction |
+| `index_unsupported` | Index op on something other than array+int or hash+key |
+| `inline_too_deep` | Inline depth exceeded `MAX_INLINE_DEPTH` (3) |
+| `inline_callee_has_loop` | Tried to inline a function containing a backward jump |
+| `builtin_call` | Built-in call other than the inlinable `len()` / `push()` |
+| `string_concat_localconst` | String concat in OpGetLocalAddConst path |
+
+Future versions may add reasons; consumers should treat unknown reasons
+as opaque strings.
+
+```json
+{"v":1,"t":"trace_abort","key":"99:50","reason":"float_arith","ir":3}
+```
+
+### `compile`
+
+The optimizer + compiler ran on a completed trace. `ok` indicates whether
+compilation produced a callable JS function. `kind` is `loop`, `side`, or
+`func`. `ir` and `guards` are the **post-optimization** counts (typically
+smaller than the `trace_complete` counts due to dedup and DCE).
+
+```json
+{"v":1,"t":"compile","key":"42:108","ok":true,"ir":19,"guards":3,"kind":"loop"}
+```
+
+### `recompile_inline`
+
+A parent trace was recompiled with a side trace inlined into its body.
+
+```json
+{"v":1,"t":"recompile_inline","key":"42:108","side_traces":1}
+```
+
+### `trace_exit`
+
+A compiled trace returned from execution with an exit reason. `exit` is
+one of `guard`, `guard_falsy`, `guard_truthy`, `loop_back`, `max_iter`,
+or `call`. For guard exits, `guard_idx` and `side_exit_count` are
+included so consumers can track which guard sites are getting hot.
+
+```json
+{"v":1,"t":"trace_exit","key":"42:108","exit":"guard_falsy","guard_idx":8,"side_exit_count":1}
+{"v":1,"t":"trace_exit","key":"42:108","exit":"loop_back"}
+{"v":1,"t":"trace_exit","key":"42:108","exit":"max_iter"}
+```
+
+### `side_trace_promote`
+
+A guard exit reached `HOT_EXIT_THRESHOLD` (currently 8) and the JIT will
+start recording a side trace from it on the next exit.
+
+```json
+{"v":1,"t":"side_trace_promote","parent":"42:108","guard_idx":2}
+```
+
+### `trace_invalidate`
+
+A `GUARD_CLOSURE` guard mismatched, indicating the parent trace was
+recorded for a different closure than the one currently executing. The
+trace is deleted and may be re-recorded.
+
+```json
+{"v":1,"t":"trace_invalidate","key":"42:108"}
+```
+
+### `inline_enter` / `inline_leave`
+
+The recorder entered or left an inlined function frame. `depth` is the
+new nesting depth (1, 2, 3...). `call_site_ip` is the bytecode IP of the
+enclosing call instruction.
+
+```json
+{"v":1,"t":"inline_enter","key":"42:108","depth":1,"call_site_ip":150}
+{"v":1,"t":"inline_leave","key":"42:108","depth":0}
+```
+
+### `inline_max_depth`
+
+The recorder tried to enter an inlined frame but `MAX_INLINE_DEPTH` (3)
+was already reached. The trace will abort with reason `inline_too_deep`.
+
+```json
+{"v":1,"t":"inline_max_depth","key":"42:108","depth":3}
+```
+
+### `blacklisted`
+
+A trace key reached 3 aborts and was blacklisted. The JIT will no longer
+attempt to record traces at this site.
+
+```json
+{"v":1,"t":"blacklisted","key":"99:50","abort_count":3}
+```
+
+## Summary blob
+
+When `JIT_EVENTS=summary` (or the `--trace-info` CLI flag) is set, a
+single JSON object is written to stderr at the end of the run. This is
+the historical `--trace-info` output, now carrying `v:1`:
+
+```json
+{
+  "v":1,
+  "engine":"jit",
+  "elapsed_ms":12.66,
+  "traces":1,
+  "side_traces":0,
+  "total_ir":19,
+  "total_guards":0,
+  "hot_sites":1,
+  "blacklisted":0,
+  "aborts":0,
+  "trace_details":[
+    {"key":"27:159","ir_ops":19,"guards":0,"side_traces":0,"compiled":true}
+  ]
+}
+```
+
+The summary blob fields are unchanged from before the introduction of
+`JIT_EVENTS` (the only addition is the `v` field). Existing consumers of
+`--trace-info` continue to work without modification.
+
+## Performance
+
+When `JIT_EVENTS=off` (the default), the cost is one branch check at each
+of ~25 emit sites. V8 inlines and folds these so the overhead is
+unmeasurable in practice.
+
+When `JIT_EVENTS=full`, the overhead depends entirely on how often the
+recorder runs and how big the recorded traces are:
+
+- Long compute loops (single trace, 100K iterations): ~38 events,
+  ~2.5 KB stream, no measurable slowdown — the hot loop runs without
+  emitting since events fire only during recording, not during compiled
+  trace execution.
+- Trace-churn workloads with many aborts (e.g. `examples/mandelbrot.monkey`,
+  which exercises lots of inlining and side-trace promotion): ~108K
+  events, ~6.6 MB stream, ~4.5× slowdown driven by `JSON.stringify` and
+  unbuffered `stderr.write` per event.
+
+Stream output is unbuffered (every event flushes), so consumers can read
+line-by-line as the program runs without waiting for the program to
+finish.
+
+## Stability
+
+The schema follows additive evolution: new event types and new fields can
+appear in future versions, but existing fields will not change shape or
+meaning within `v:1`. Breaking changes will bump the version.
+
+Consumers should:
+- Match on the `t` field as the dispatch key
+- Ignore unknown event types and unknown fields
+- Not assume a fixed event ordering except where causally implied
+  (e.g. `trace_start` always precedes `trace_complete`/`trace_abort`
+  for the same key)

--- a/projects/monkey-lang/src/jit-events.test.js
+++ b/projects/monkey-lang/src/jit-events.test.js
@@ -1,0 +1,217 @@
+// JIT event instrumentation tests
+//
+// Verifies the per-event JSON Lines stream that fires when JIT_EVENTS=full.
+// Spawns a child node process for each test so the env var can be set
+// independently — the JIT_EVENTS_FULL constant is captured at module load
+// time, so we can't toggle it from inside the same process.
+
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { strict as assert } from 'node:assert';
+import { describe, it, before, after } from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPL = join(__dirname, 'repl.js');
+
+let TMP;
+before(() => { TMP = mkdtempSync(join(tmpdir(), 'jit-events-')); });
+after(() => { rmSync(TMP, { recursive: true, force: true }); });
+
+function runWithEvents(source, env = {}) {
+  const path = join(TMP, `prog-${Math.random().toString(36).slice(2)}.monkey`);
+  writeFileSync(path, source);
+  const result = spawnSync('node', [REPL, path], {
+    env: { ...process.env, ...env },
+    encoding: 'utf-8',
+  });
+  // Parse stderr line-by-line as JSONL; ignore non-JSON lines.
+  const events = [];
+  for (const line of result.stderr.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    try { events.push(JSON.parse(trimmed)); } catch {}
+  }
+  return { events, stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
+const HOT_LOOP = `
+let sum = 0;
+let i = 0;
+while (i < 30) { sum = sum + i; i = i + 1; }
+puts(sum);
+`;
+
+describe('JIT events: gate', () => {
+  it('emits no events when JIT_EVENTS is unset', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: '' });
+    assert.equal(events.length, 0, 'JIT_EVENTS=off should suppress all event lines');
+  });
+
+  it('emits no events when JIT_EVENTS=summary (only the end-of-run blob if --trace-info)', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'summary' });
+    // JIT_EVENTS=summary triggers the same end-of-run blob as --trace-info.
+    // No per-event stream lines should appear.
+    const streamEvents = events.filter(e => e.t);
+    assert.equal(streamEvents.length, 0, 'summary tier should not emit per-event lines');
+    // The summary blob should be present and carry the schema version.
+    const blob = events.find(e => !e.t && e.v === 1);
+    assert.ok(blob, 'summary tier should still emit the end-of-run blob');
+    assert.equal(blob.v, 1);
+  });
+
+  it('emits the per-event stream when JIT_EVENTS=full', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const streamEvents = events.filter(e => e.t);
+    assert.ok(streamEvents.length > 0, 'full tier should emit stream events');
+  });
+});
+
+describe('JIT events: schema', () => {
+  it('every event carries v:1', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const stream = events.filter(e => e.t);
+    for (const e of stream) {
+      assert.equal(e.v, 1, `event ${e.t} missing schema version`);
+    }
+  });
+
+  it('summary blob carries v:1', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'summary' });
+    const blob = events.find(e => !e.t);
+    assert.ok(blob);
+    assert.equal(blob.v, 1);
+  });
+});
+
+describe('JIT events: lifecycle', () => {
+  it('emits loop_hot → trace_start → trace_complete → compile sequence', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const types = events.filter(e => e.t).map(e => e.t);
+    const hotIdx = types.indexOf('loop_hot');
+    const startIdx = types.indexOf('trace_start');
+    const completeIdx = types.indexOf('trace_complete');
+    const compileIdx = types.indexOf('compile');
+    assert.ok(hotIdx >= 0, 'loop_hot event missing');
+    assert.ok(startIdx > hotIdx, 'trace_start must follow loop_hot');
+    assert.ok(completeIdx > startIdx, 'trace_complete must follow trace_start');
+    assert.ok(compileIdx > completeIdx, 'compile must follow trace_complete');
+  });
+
+  it('compile event reports ok=true and IR/guard counts', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const compile = events.find(e => e.t === 'compile');
+    assert.ok(compile, 'compile event missing');
+    assert.equal(compile.ok, true);
+    assert.equal(typeof compile.ir, 'number');
+    assert.equal(typeof compile.guards, 'number');
+    assert.ok(compile.ir > 0);
+  });
+
+  it('trace_complete reports IR and guard counts', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const complete = events.find(e => e.t === 'trace_complete');
+    assert.ok(complete);
+    assert.ok(complete.ir > 0);
+    assert.ok(complete.guards >= 0);
+  });
+});
+
+describe('JIT events: uop and guard streams', () => {
+  it('emits uop events with opcode names', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const uops = events.filter(e => e.t === 'uop');
+    assert.ok(uops.length > 0);
+    // Should see several distinct IR ops in a hot loop body
+    const ops = new Set(uops.map(u => u.op));
+    assert.ok(ops.has('add_int'), 'add_int uop expected for hot int loop');
+    assert.ok(ops.has('load_global'), 'load_global uop expected');
+  });
+
+  it('emits guard events distinct from uop events for guard ops', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const guards = events.filter(e => e.t === 'guard');
+    assert.ok(guards.length > 0);
+    // Each guard event has a guard_idx
+    for (const g of guards) {
+      assert.equal(typeof g.guard_idx, 'number');
+      assert.ok(g.op.startsWith('guard_'));
+    }
+  });
+
+  it('uop events carry minimal operand identifiers', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const uops = events.filter(e => e.t === 'uop');
+    const loadGlobals = uops.filter(u => u.op === 'load_global');
+    assert.ok(loadGlobals.length > 0);
+    // load_global should have an `index` operand
+    assert.ok(loadGlobals.every(u => typeof u.index === 'number'));
+  });
+});
+
+describe('JIT events: trace_exit', () => {
+  it('emits trace_exit events with exit reason', () => {
+    const { events } = runWithEvents(HOT_LOOP, { JIT_EVENTS: 'full' });
+    const exits = events.filter(e => e.t === 'trace_exit');
+    assert.ok(exits.length > 0, 'trace_exit event missing');
+    for (const e of exits) {
+      assert.ok(e.exit, `trace_exit missing exit field: ${JSON.stringify(e)}`);
+    }
+  });
+});
+
+describe('JIT events: abort path', () => {
+  const ABORT_PROG = `
+let i = 0.0;
+let total = 0.0;
+while (i < 50.0) { total = total + i; i = i + 1.0; }
+puts(total);
+`;
+
+  it('emits trace_abort with reason for bailout-triggering programs', () => {
+    const { events } = runWithEvents(ABORT_PROG, { JIT_EVENTS: 'full' });
+    const aborts = events.filter(e => e.t === 'trace_abort');
+    assert.ok(aborts.length > 0, 'expected at least one trace_abort');
+    for (const a of aborts) {
+      assert.ok(a.reason, 'trace_abort missing reason');
+      assert.notEqual(a.reason, 'unknown', 'reason should be specific, not "unknown"');
+    }
+  });
+
+  it('emits blacklisted event after 3 aborts at the same site', () => {
+    const { events } = runWithEvents(ABORT_PROG, { JIT_EVENTS: 'full' });
+    const blacklisted = events.filter(e => e.t === 'blacklisted');
+    assert.equal(blacklisted.length, 1, 'blacklist should fire exactly once per key');
+    assert.ok(blacklisted[0].abort_count >= 3);
+  });
+});
+
+describe('JIT events: --trace-info compatibility', () => {
+  it('--trace-info still emits the summary blob with v:1', () => {
+    const path = join(TMP, 'compat.monkey');
+    writeFileSync(path, HOT_LOOP);
+    const result = spawnSync('node', [REPL, path, '--trace-info'], { encoding: 'utf-8' });
+    const lines = result.stderr.split('\n').filter(l => l.trim().startsWith('{'));
+    const blob = lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).find(o => o && !o.t);
+    assert.ok(blob, '--trace-info should emit one summary blob');
+    assert.equal(blob.v, 1);
+    assert.ok('traces' in blob);
+    assert.ok('hot_sites' in blob);
+  });
+
+  it('--trace-info preserves all preexisting summary fields', () => {
+    const path = join(TMP, 'compat2.monkey');
+    writeFileSync(path, HOT_LOOP);
+    const result = spawnSync('node', [REPL, path, '--trace-info'], { encoding: 'utf-8' });
+    const lines = result.stderr.split('\n').filter(l => l.trim().startsWith('{'));
+    const blob = lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).find(o => o && !o.t);
+    // These fields existed before this PR — must still be present.
+    for (const field of ['engine', 'elapsed_ms', 'traces', 'side_traces',
+                         'total_ir', 'total_guards', 'hot_sites', 'blacklisted',
+                         'aborts', 'trace_details']) {
+      assert.ok(field in blob, `summary blob missing preexisting field: ${field}`);
+    }
+  });
+});

--- a/projects/monkey-lang/src/jit.js
+++ b/projects/monkey-lang/src/jit.js
@@ -12,6 +12,13 @@
 // But we CAN generate optimized JS that V8/SpiderMonkey will JIT-compile.
 // This eliminates: dispatch overhead, stack push/pop, object wrapping.
 // The generated JS operates on raw values where possible.
+//
+// --- JIT event instrumentation ---
+// When JIT_EVENTS=full is set in the environment, the JIT emits one JSON
+// line per event to stderr (versioned schema, "v":1). When unset or set
+// to anything other than "full", emission is disabled and the cost is a
+// single branch check at each emit site. See JIT_EVENTS_SCHEMA.md for
+// the event vocabulary.
 
 import { Opcodes, lookup } from './code.js';
 import {
@@ -20,6 +27,21 @@ import {
   TRUE, FALSE, NULL, cachedInteger,
 } from './object.js';
 import { CompiledFunction } from './compiler.js';
+
+// --- JIT event instrumentation ---
+const JIT_EVENTS_MODE = (typeof process !== 'undefined' && process.env && process.env.JIT_EVENTS) || 'off';
+export const JIT_EVENTS_FULL = JIT_EVENTS_MODE === 'full';
+export const JIT_EVENTS_SUMMARY = JIT_EVENTS_MODE === 'summary' || JIT_EVENTS_FULL;
+export const JIT_EVENTS_SCHEMA_VERSION = 1;
+
+// Emit a single event as a JSON line on stderr.
+// Caller MUST gate on JIT_EVENTS_FULL before calling — this function
+// assumes emission is desired and skips the early-out check so the
+// hot-path uop emitter doesn't pay for two checks.
+function emitEvent(event) {
+  event.v = JIT_EVENTS_SCHEMA_VERSION;
+  process.stderr.write(JSON.stringify(event) + '\n');
+}
 
 // --- Configuration ---
 const HOT_LOOP_THRESHOLD = 16;   // iterations before tracing starts
@@ -147,6 +169,16 @@ export class Trace {
     const inst = new IRInst(op, operands);
     inst.id = this.ir.length;
     this.ir.push(inst);
+    if (JIT_EVENTS_FULL) {
+      // Minimal payload: opcode + the most useful operand identifiers,
+      // skipping bulky values. This is the highest-volume event type.
+      const ev = { t: 'uop', key: `${this.frameId}:${this.startIp}`, op };
+      if (operands.slot !== undefined) ev.slot = operands.slot;
+      if (operands.index !== undefined) ev.index = operands.index;
+      if (operands.constIdx !== undefined) ev.const_idx = operands.constIdx;
+      if (operands.ref !== undefined) ev.ref = operands.ref;
+      emitEvent(ev);
+    }
     return inst.id;
   }
 }
@@ -207,6 +239,10 @@ export class TraceRecorder {
     this.parentTrace = null;
     this.parentGuardIdx = -1;
 
+    if (JIT_EVENTS_FULL) {
+      emitEvent({ t: 'trace_start', key: `${frameId}:${ip}`, kind: 'loop' });
+    }
+
     // Record loop start marker
     this.trace.addInst(IR.LOOP_START);
   }
@@ -230,6 +266,16 @@ export class TraceRecorder {
     this.trustedTypes.clear();
     this.parentTrace = parentTrace;
     this.parentGuardIdx = guardIdx;
+
+    if (JIT_EVENTS_FULL) {
+      emitEvent({
+        t: 'trace_start',
+        key: `${frameId}:${exitIp}`,
+        kind: 'side',
+        parent: `${parentTrace.frameId}:${parentTrace.startIp}`,
+        guard_idx: guardIdx,
+      });
+    }
 
     // No LOOP_START for side traces — they're linear paths
     // that end at the parent's loop header
@@ -256,6 +302,10 @@ export class TraceRecorder {
     this.isFuncTrace = true;
     this.tracedFn = fn;
 
+    if (JIT_EVENTS_FULL) {
+      emitEvent({ t: 'trace_start', key: `${frameId}:0`, kind: 'func', num_args: numArgs });
+    }
+
     // Load args as LOAD_LOCAL with guard
     for (let i = 0; i < numArgs; i++) {
       const ref = this.trace.addInst(IR.LOAD_LOCAL, { slot: i });
@@ -277,6 +327,14 @@ export class TraceRecorder {
     }
     const trace = this.trace;
     this.trace = null;
+    if (JIT_EVENTS_FULL) {
+      emitEvent({
+        t: 'trace_complete',
+        key: `${trace.frameId}:${trace.startIp}`,
+        ir: trace.ir.length,
+        guards: trace.guardCount,
+      });
+    }
     return trace;
   }
 
@@ -286,7 +344,15 @@ export class TraceRecorder {
     return ip === this.parentTrace.startIp && frameIndex === this.startFrame;
   }
 
-  abort() {
+  abort(reason = 'unknown') {
+    if (JIT_EVENTS_FULL && this.trace) {
+      emitEvent({
+        t: 'trace_abort',
+        key: `${this.trace.frameId}:${this.trace.startIp}`,
+        reason,
+        ir: this.trace.ir.length,
+      });
+    }
     this.recording = false;
     this.trace = null;
     this.irStack = [];
@@ -299,7 +365,16 @@ export class TraceRecorder {
   // numLocals: callee's numLocals (to know the stack layout)
   // callSiteIp: the IP in the caller frame right after the OpCall (for guard exit fallback)
   enterInlineFrame(baseOffset, numLocals, callSiteIp) {
-    if (this.inlineDepth >= MAX_INLINE_DEPTH) return false;
+    if (this.inlineDepth >= MAX_INLINE_DEPTH) {
+      if (JIT_EVENTS_FULL && this.trace) {
+        emitEvent({
+          t: 'inline_max_depth',
+          key: `${this.trace.frameId}:${this.trace.startIp}`,
+          depth: this.inlineDepth,
+        });
+      }
+      return false;
+    }
     this.inlineFrames.push({
       baseOffset,
       numLocals,
@@ -307,6 +382,14 @@ export class TraceRecorder {
       callSiteIp,  // used for guard exits inside the inlined function
     });
     this.inlineDepth++;
+    if (JIT_EVENTS_FULL && this.trace) {
+      emitEvent({
+        t: 'inline_enter',
+        key: `${this.trace.frameId}:${this.trace.startIp}`,
+        depth: this.inlineDepth,
+        call_site_ip: callSiteIp,
+      });
+    }
     return true;
   }
 
@@ -319,6 +402,13 @@ export class TraceRecorder {
       this.inlineSlotRefs.delete(frame.baseOffset + i);
     }
     this.inlineDepth--;
+    if (JIT_EVENTS_FULL && this.trace) {
+      emitEvent({
+        t: 'inline_leave',
+        key: `${this.trace.frameId}:${this.trace.startIp}`,
+        depth: this.inlineDepth,
+      });
+    }
   }
 
   // Get the current base offset for local variable addressing
@@ -385,6 +475,18 @@ export class TraceRecorder {
     const gid = this.trace.addInst(op, operands);
     const inst = this.trace.ir[gid];
     inst.snapshot = this.captureSnapshot();
+    if (JIT_EVENTS_FULL) {
+      // Tag the guard subset specifically — addInst already emitted a uop event
+      // for it; this gives mimule's coverage manager a separate guard channel.
+      const ev = {
+        t: 'guard',
+        key: `${this.trace.frameId}:${this.trace.startIp}`,
+        op,
+        guard_idx: gid,
+      };
+      if (operands.ref !== undefined) ev.ref = operands.ref;
+      emitEvent(ev);
+    }
     return gid;
   }
 
@@ -563,6 +665,9 @@ export class JIT {
     if (this.blacklisted.has(key)) return false;
     const count = (this.hotCounts.get(key) || 0) + 1;
     this.hotCounts.set(key, count);
+    if (JIT_EVENTS_FULL && count === HOT_LOOP_THRESHOLD) {
+      emitEvent({ t: 'loop_hot', key, count });
+    }
     return count >= HOT_LOOP_THRESHOLD;
   }
 
@@ -571,8 +676,11 @@ export class JIT {
     const key = this.traceKey(closureId, ip);
     const count = (this.abortCounts.get(key) || 0) + 1;
     this.abortCounts.set(key, count);
-    if (count >= 3) {
+    if (count >= 3 && !this.blacklisted.has(key)) {
       this.blacklisted.add(key);
+      if (JIT_EVENTS_FULL) {
+        emitEvent({ t: 'blacklisted', key, abort_count: count });
+      }
     }
   }
 
@@ -606,7 +714,16 @@ export class JIT {
     try {
       const compiler = new TraceCompiler(parentTrace);
       const newCompiled = compiler.compile();
-      if (newCompiled) parentTrace.compiled = newCompiled;
+      if (newCompiled) {
+        parentTrace.compiled = newCompiled;
+        if (JIT_EVENTS_FULL) {
+          emitEvent({
+            t: 'recompile_inline',
+            key: `${parentTrace.frameId}:${parentTrace.startIp}`,
+            side_traces: parentTrace._sideTraceCount,
+          });
+        }
+      }
     } catch (e) {
       // If recompilation fails, keep the old compiled function
     }
@@ -625,6 +742,9 @@ export class JIT {
   countFuncCall(fn) {
     const count = (this.funcCallCounts.get(fn) || 0) + 1;
     this.funcCallCounts.set(fn, count);
+    if (JIT_EVENTS_FULL && count === HOT_FUNC_THRESHOLD) {
+      emitEvent({ t: 'func_hot', fn_id: fn.id, count });
+    }
     return count >= HOT_FUNC_THRESHOLD;
   }
 
@@ -672,7 +792,18 @@ export class JIT {
 
     const compiler = new TraceCompiler(trace, vm);
     trace.compiled = compiler.compile();
-    return trace.compiled !== null;
+    const ok = trace.compiled !== null;
+    if (JIT_EVENTS_FULL) {
+      emitEvent({
+        t: 'compile',
+        key: `${trace.frameId}:${trace.startIp}`,
+        ok,
+        ir: trace.ir.length,
+        guards: trace.guardCount,
+        kind: trace.isFuncTrace ? 'func' : (trace.isSideTrace ? 'side' : 'loop'),
+      });
+    }
+    return ok;
   }
 
   // Get JIT statistics for diagnostics
@@ -699,6 +830,7 @@ export class JIT {
     }
 
     return {
+      v: JIT_EVENTS_SCHEMA_VERSION,
       enabled: this.enabled,
       rootTraces,
       sideTraces: sideTraceCount,

--- a/projects/monkey-lang/src/repl.js
+++ b/projects/monkey-lang/src/repl.js
@@ -11,7 +11,7 @@ import { Parser } from './parser.js';
 import { monkeyEval } from './evaluator.js';
 import { Compiler } from './compiler.js';
 import { VM } from './vm.js';
-import { IR } from './jit.js';
+import { IR, JIT_EVENTS_FULL, JIT_EVENTS_SUMMARY, JIT_EVENTS_SCHEMA_VERSION } from './jit.js';
 import { Environment, NULL } from './object.js';
 import { STDLIB_SOURCE } from './stdlib.js';
 import { compileAndRun as wasmCompileAndRun, WasmCompiler, formatWasmValue } from './wasm-compiler.js';
@@ -323,7 +323,10 @@ if (fileArg) {
       // Determine engine from flags
       const engineArg = process.argv.find(a => a.startsWith('--engine='));
       const engineName = engineArg ? engineArg.split('=')[1] : 'vm';
-      const traceInfo = process.argv.includes('--trace-info');
+      // --trace-info CLI flag and JIT_EVENTS env var both request JIT activity.
+      // JIT_EVENTS=summary mirrors --trace-info; JIT_EVENTS=full additionally
+      // emits a per-event JSON Lines stream (see JIT_EVENTS_SCHEMA.md).
+      const traceInfo = process.argv.includes('--trace-info') || JIT_EVENTS_SUMMARY;
       const diffTest = process.argv.includes('--diff-test');
       const useJIT = traceInfo || diffTest || engineName === 'jit';
 
@@ -359,6 +362,7 @@ if (fileArg) {
       if (traceInfo && vm.jit) {
         const stats = vm.jit.getStats();
         const diagInfo = {
+          v: JIT_EVENTS_SCHEMA_VERSION,
           engine: useJIT ? 'jit' : 'vm',
           elapsed_ms: Math.round(elapsed * 100) / 100,
           traces: stats.rootTraces,

--- a/projects/monkey-lang/src/vm.js
+++ b/projects/monkey-lang/src/vm.js
@@ -9,7 +9,7 @@ import {
   MonkeyResult, MonkeyEnum,
   TRUE, FALSE, NULL, cachedInteger, internString,
 } from './object.js';
-import { IR, JIT, TraceRecorder } from './jit.js';
+import { IR, JIT, TraceRecorder, JIT_EVENTS_FULL } from './jit.js';
 
 const STACK_SIZE = 2048;
 const GLOBALS_SIZE = 65536;
@@ -502,7 +502,7 @@ export class VM {
 
       // Abort recording on too many instructions
       if (recording() && ++this.recorder.instrCount > 200) {
-        this._abortRecording();
+        this._abortRecording('instr_count_max');
       }
 
       switch (op) {
@@ -557,7 +557,7 @@ export class VM {
                      (left instanceof MonkeyInteger || left instanceof MonkeyFloat) &&
                      (right instanceof MonkeyInteger || right instanceof MonkeyFloat)) {
             // Float arithmetic
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('float_arith'); }
             let result;
             switch (op) {
               case Opcodes.OpAdd: result = left.value + right.value; break;
@@ -658,7 +658,7 @@ export class VM {
             }
             this.push(result ? TRUE : FALSE);
           } else if (left2 instanceof MonkeyBoolean && right2 instanceof MonkeyBoolean) {
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('bool_compare'); }
             let result;
             switch (op) {
               case Opcodes.OpEqual: result = left2.value === right2.value; break;
@@ -669,7 +669,7 @@ export class VM {
           } else if ((left2 instanceof MonkeyFloat || right2 instanceof MonkeyFloat) &&
                      (left2 instanceof MonkeyInteger || left2 instanceof MonkeyFloat) &&
                      (right2 instanceof MonkeyInteger || right2 instanceof MonkeyFloat)) {
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('mixed_numeric_compare'); }
             let result;
             switch (op) {
               case Opcodes.OpEqual: result = left2.value === right2.value; break;
@@ -678,7 +678,7 @@ export class VM {
             }
             this.push(result ? TRUE : FALSE);
           } else if (left2 instanceof MonkeyString && right2 instanceof MonkeyString) {
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('string_compare'); }
             let result;
             switch (op) {
               case Opcodes.OpEqual: result = left2.value === right2.value; break;
@@ -688,11 +688,11 @@ export class VM {
             this.push(result ? TRUE : FALSE);
           } else if (left2 === NULL || right2 === NULL) {
             // Null comparison: null == null is true, null == anything_else is false
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('null_compare'); }
             const result = op === Opcodes.OpEqual ? (left2 === right2) : (left2 !== right2);
             this.push(result ? TRUE : FALSE);
           } else if (left2 instanceof MonkeyEnum && right2 instanceof MonkeyEnum) {
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('enum_compare'); }
             const eq = left2.enumName === right2.enumName && left2.variant === right2.variant;
             const result = op === Opcodes.OpEqual ? eq : !eq;
             this.push(result ? TRUE : FALSE);
@@ -705,7 +705,7 @@ export class VM {
         case Opcodes.OpMinus: {
           const operand = this.pop();
           if (operand instanceof MonkeyFloat) {
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('float_negate'); }
             this.push(new MonkeyFloat(-operand.value));
             break;
           }
@@ -885,7 +885,7 @@ export class VM {
         }
 
         case Opcodes.OpArray: {
-          if (recording()) { this._abortRecording(); }
+          if (recording()) { this._abortRecording('array_lit'); }
           const numElements = (ins[ip + 1] << 8) | ins[ip + 2];
           frame.ip += 2;
           const elements = this.stack.slice(this.sp - numElements, this.sp);
@@ -895,7 +895,7 @@ export class VM {
         }
 
         case Opcodes.OpHash: {
-          if (recording()) { this._abortRecording(); }
+          if (recording()) { this._abortRecording('hash_lit'); }
           const numPairs = (ins[ip + 1] << 8) | ins[ip + 2];
           frame.ip += 2;
           const pairs = new Map();
@@ -959,7 +959,7 @@ export class VM {
               this.recorder.typeMap.set(resultRef, 'object');
               this.recorder.pushRef(resultRef);
             } else {
-              this._abortRecording();
+              this._abortRecording('index_unsupported');
             }
           }
           if (left3 instanceof MonkeyArray && index instanceof MonkeyInteger) {
@@ -1116,11 +1116,11 @@ export class VM {
 
               if (!this.recorder.enterInlineFrame(baseOffset, callee.fn.numLocals, ip)) {
                 // Too deep — abort recording
-                this._abortRecording();
+                this._abortRecording('inline_too_deep');
               } else if (this._hasBackwardJump(callee.fn.instructions)) {
                 // Function contains a loop — don't inline, too complex
                 this.recorder.leaveInlineFrame();
-                this._abortRecording();
+                this._abortRecording('inline_callee_has_loop');
               } else {
                 // Map the argument IR refs to the inlined frame's local slots
                 // so that LOAD_LOCAL in the callee picks them up directly
@@ -1181,7 +1181,7 @@ export class VM {
               this.sp = this.sp - numArgs - 1;
               this.push(result !== undefined ? result : NULL);
             } else {
-              if (recording()) { this._abortRecording(); }
+              if (recording()) { this._abortRecording('builtin_call'); }
               const args = this.stack.slice(this.sp - numArgs, this.sp);
               const result = callee.fn(...args);
               this.sp = this.sp - numArgs - 1;
@@ -1646,7 +1646,7 @@ export class VM {
             }
             this.push(cachedInteger(result));
           } else if (leftVal instanceof MonkeyString && rightVal instanceof MonkeyString && op === Opcodes.OpGetLocalAddConst) {
-            if (recording()) { this._abortRecording(); }
+            if (recording()) { this._abortRecording('string_concat_localconst'); }
             this.push(new MonkeyString(leftVal.value + rightVal.value));
           } else {
             throw new Error(`unsupported types for local+const op: ${leftVal.type()} and ${rightVal.type()}`);
@@ -1943,6 +1943,7 @@ export class VM {
 
       if (!result) return false;
 
+      const traceKey = `${trace.frameId}:${trace.startIp}`;
       switch (result.exit) {
         case 'guard_falsy':
         case 'guard_truthy':
@@ -1967,14 +1968,30 @@ export class VM {
             }
           }
 
-          trace.sideExits.set(result.guardIdx,
-            (trace.sideExits.get(result.guardIdx) || 0) + 1);
+          {
+            const newCount = (trace.sideExits.get(result.guardIdx) || 0) + 1;
+            trace.sideExits.set(result.guardIdx, newCount);
+            if (JIT_EVENTS_FULL) {
+              process.stderr.write(JSON.stringify({
+                v: 1, t: 'trace_exit', key: traceKey, exit: result.exit,
+                guard_idx: result.guardIdx, side_exit_count: newCount,
+              }) + '\n');
+            }
+          }
 
           if (this.jit && !this.recorder && this.jit.shouldRecordSideTrace(trace, result.guardIdx)) {
+            if (JIT_EVENTS_FULL) {
+              process.stderr.write(JSON.stringify({
+                v: 1, t: 'side_trace_promote', parent: traceKey, guard_idx: result.guardIdx,
+              }) + '\n');
+            }
             this._startSideTraceRecording(trace, result.guardIdx, result.ip);
           }
           return true;
         case 'loop_back':
+          if (JIT_EVENTS_FULL) {
+            process.stderr.write(JSON.stringify({ v: 1, t: 'trace_exit', key: traceKey, exit: 'loop_back' }) + '\n');
+          }
           return true;
         case 'invalidate':
           // Guard closure mismatch — delete this trace so a new one will be recorded
@@ -1983,12 +2000,21 @@ export class VM {
             if (t === trace) { this.jit.traces.delete(key); break; }
           }
           frame.ip = trace.startIp - 1;
+          if (JIT_EVENTS_FULL) {
+            process.stderr.write(JSON.stringify({ v: 1, t: 'trace_invalidate', key: traceKey }) + '\n');
+          }
           return true;
         case 'max_iter':
           frame.ip = trace.startIp - 1;
+          if (JIT_EVENTS_FULL) {
+            process.stderr.write(JSON.stringify({ v: 1, t: 'trace_exit', key: traceKey, exit: 'max_iter' }) + '\n');
+          }
           return true;
         case 'call':
           frame.ip = trace.startIp - 1;
+          if (JIT_EVENTS_FULL) {
+            process.stderr.write(JSON.stringify({ v: 1, t: 'trace_exit', key: traceKey, exit: 'call' }) + '\n');
+          }
           return true;
         default:
           return true;
@@ -2002,11 +2028,11 @@ export class VM {
     this.recorder.start(this._closureId(), ip);
   }
 
-  _abortRecording() {
+  _abortRecording(reason = 'unknown') {
     if (this.recorder && this.jit) {
       this.jit.recordAbort(this.recorder.trace?.frameId ?? this._closureId(), this.recorder.startIp);
     }
-    if (this.recorder) this.recorder.abort();
+    if (this.recorder) this.recorder.abort(reason);
     this.recorder = null;
   }
 
@@ -2127,7 +2153,7 @@ export class VM {
 
     // Abort on too many instructions
     if (++this.recorder.instrCount > 200) {
-      this._abortRecording();
+      this._abortRecording('instr_count_max_func');
       return;
     }
   }


### PR DESCRIPTION
## Summary

Extends the existing `--trace-info` summary tier you shipped in `a22b36b7` with a per-event JSON Lines stream gated by a new `JIT_EVENTS=full` environment variable. Designed for fuzzer tooling (mimule, the lafleur descendant we discussed) and JIT debugging.

This is the implementation of the proposal you greenlit in your last message — both the env-var gating and the schema versioning, with both tiers from day one.

## Design recap

| Mode | Behavior |
|-|-|
| `JIT_EVENTS=off` (default) | No events emitted, no overhead |
| `JIT_EVENTS=summary` | End-of-run summary blob only — same as `--trace-info` |
| `JIT_EVENTS=full` | Summary blob **plus** per-event JSON Lines stream |

The `--trace-info` CLI flag is now equivalent to `JIT_EVENTS=summary`. Setting both is harmless. The existing summary blob is **unchanged in shape** — it just gains a `v:1` field. All preexisting `--trace-info` consumers continue to work without modification.

## What the full-tier stream looks like

Every event is one JSON line on stderr, carrying `v:1` (schema version), `t` (event type), and a `key` (\`closureId:ip\`) plus event-specific fields. Example session for a small hot loop:

```jsonl
{\"v\":1,\"t\":\"loop_hot\",\"key\":\"27:159\",\"count\":16}
{\"v\":1,\"t\":\"trace_start\",\"key\":\"27:159\",\"kind\":\"loop\"}
{\"v\":1,\"t\":\"uop\",\"key\":\"27:159\",\"op\":\"loop_start\"}
{\"v\":1,\"t\":\"uop\",\"key\":\"27:159\",\"op\":\"load_global\",\"index\":22}
{\"v\":1,\"t\":\"uop\",\"key\":\"27:159\",\"op\":\"guard_int\",\"ref\":2}
{\"v\":1,\"t\":\"guard\",\"key\":\"27:159\",\"op\":\"guard_int\",\"guard_idx\":3,\"ref\":2}
... (more uop/guard events)
{\"v\":1,\"t\":\"trace_complete\",\"key\":\"27:159\",\"ir\":27,\"guards\":5}
{\"v\":1,\"t\":\"compile\",\"key\":\"27:159\",\"ok\":true,\"ir\":19,\"guards\":3,\"kind\":\"loop\"}
{\"v\":1,\"t\":\"trace_exit\",\"key\":\"27:159\",\"exit\":\"guard_falsy\",\"guard_idx\":8,\"side_exit_count\":1}
```

Fifteen event types total covering the full lifecycle. Full vocabulary in **`JIT_EVENTS_SCHEMA.md`** (added in this PR).

## Bug-bonus: 16 specific abort reasons

The previous `_abortRecording()` was parameterless, so when traces aborted you couldn't tell why. This PR threads a \`reason\` parameter through all 16 call sites in `vm.js` with specific labels:

`instr_count_max`, `float_arith`, `bool_compare`, `mixed_numeric_compare`, `string_compare`, `null_compare`, `enum_compare`, `float_negate`, `array_lit`, `hash_lit`, `index_unsupported`, `inline_too_deep`, `inline_callee_has_loop`, `builtin_call`, `string_concat_localconst`, `instr_count_max_func`.

Even without `JIT_EVENTS=full`, this is now visible if you ever want to debug \"why isn't the JIT recording trace X?\" — though the events only fire under full mode.

## Hot-path cost

`emitEvent()` sites all gate on \`if (JIT_EVENTS_FULL)\` first. V8 inlines and folds these constant checks, so the `JIT_EVENTS=off` path has no measurable overhead vs main:

| Mode | 100K-iter int loop |
|-|-|
| main | 14.1–15.5 ms |
| branch (`JIT_EVENTS=off`) | 12.9–14.1 ms |

Within noise. (Three runs each, baseline benchmark in the commit message.)

Under `JIT_EVENTS=full` the cost depends on trace activity:

| Workload | Events | Stream size | Slowdown |
|-|-|-|-|
| 100K-iter int loop | ~38 | 2.5 KB | none (events fire only during recording) |
| `examples/mandelbrot.monkey` | ~108K | 6.6 MB | ~4.5× |

For mimule's child-process fuzzing, even the worst case is acceptable since each child runs for seconds and stderr is consumed line-by-line without buffering. The stream is unbuffered (every event flushes), so consumers can read events as they happen rather than waiting for the program to finish.

## Files touched

| File | Lines | What |
|-|-|-|
| `src/jit.js` | +136 | Env-var gate at the top, `emitEvent()` helper, hooks at 11 sites (addInst, start, startSideTrace, startFuncTrace, stop, abort, enterInlineFrame, leaveInlineFrame, addGuardInst, countEdge, recordAbort, _recompileWithInlinedSideTraces, countFuncCall, JIT.compile). `getStats()` gains `v:1`. |
| `src/vm.js` | +56 | Imports `JIT_EVENTS_FULL`. `_abortRecording` gains `reason` parameter, threaded through 16 call sites. `_executeTrace` switch emits `trace_exit` / `trace_invalidate` events with `side_exit_count` and `guard_idx` for the guard-exit cases, plus `side_trace_promote` on `shouldRecordSideTrace`. |
| `src/repl.js` | +6 | Imports `JIT_EVENTS_SUMMARY`. `traceInfo` flag ORs with the env-var setting. `v:1` added to summary blob. |
| `src/jit-events.test.js` | +199 (new) | 16 tests covering gate, schema, lifecycle, uop/guard streams, trace_exit, abort+blacklist, and `--trace-info` backwards compatibility. |
| `JIT_EVENTS_SCHEMA.md` | +263 (new) | Schema documentation covering all 15 event types, modes, performance, and stability guarantees. |

## Test plan

- [x] `node --test src/jit-events.test.js` — 16/16 pass
- [x] `node --test src/jit.test.js src/jit-integration.test.js` — 258/258 pass (255 + 3 skipped, no change from main)
- [x] `node --test src/*.test.js` — 1552/1556 pass (same baseline as main; the 1 failing test is the preexisting `wasm-perf` binary-size assertion at `wasm-perf.test.js:40`, the 3 skipped are unrelated)
- [x] `node monkey-fuzzer.js --count=20 --seed=42` — same divergence count as main
- [x] Backwards compatibility: two test cases in \`jit-events.test.js\` explicitly verify the `--trace-info` summary blob preserves every preexisting field
- [x] Performance regression check: ran `examples/mandelbrot.monkey` under both modes; confirmed JIT_EVENTS=off is within noise of main
- [x] Smoke-tested `JIT_EVENTS=full` against trace abort path (`mixed_numeric_compare` reason fires on every abort, `blacklisted` event fires exactly once after 3 aborts)

## What's NOT in this PR

* No CLI flag `--jit-events=full` — env var only, for now. Easy to add later if you want a CLI alias.
* No per-event timestamps. The events are causally ordered via stream position, which is sufficient for fuzzing. If you want wall-clock timing later we can add a `ts` field gated by a separate option.
* No event sampling or rate limiting. mimule wants all events anyway.

## A small repo layout note

Like PR #2 (the AST serializer fix), all changes live under `projects/monkey-lang/` since that's where the 5-backend interpreter with the 4335-line `src/jit.js` lives in your fork. Happy to rebase or split if you'd rather have it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)